### PR TITLE
CI: Use forward-slashes in paths (cross-platform)

### DIFF
--- a/script/vsts/nightly-release.yml
+++ b/script/vsts/nightly-release.yml
@@ -4,10 +4,10 @@ jobs:
       # This has to be done separately because VSTS inexplicably
       # exits the script block after `npm install` completes.
       - script: |
-          cd script\vsts
+          cd script/vsts
           npm install
         displayName: npm install
-      - script: node script\vsts\get-release-version.js --nightly
+      - script: node script/vsts/get-release-version.js --nightly
         name: Version
 
   # Import OS-specific build definitions
@@ -38,7 +38,7 @@ jobs:
        #This has to be done separately because VSTS inexplicably
        #exits the script block after `npm install` completes.
       - script: |
-          cd script\vsts
+          cd script/vsts
           npm install
         displayName: npm install
 
@@ -49,7 +49,7 @@ jobs:
         displayName: Download Release Artifacts
 
       - script: |
-          node $(Build.SourcesDirectory)\script\vsts\upload-artifacts.js --create-github-release --assets-path "$(System.ArtifactsDirectory)" --linux-repo-name "atom"
+          node $(Build.SourcesDirectory)/script/vsts/upload-artifacts.js --create-github-release --assets-path "$(System.ArtifactsDirectory)" --linux-repo-name "atom"
         env:
           GITHUB_TOKEN: $(GITHUB_TOKEN)
           ATOM_RELEASE_VERSION: $(ReleaseVersion)

--- a/script/vsts/pull-requests.yml
+++ b/script/vsts/pull-requests.yml
@@ -6,10 +6,10 @@ jobs:
       # This has to be done separately because VSTS inexplicably
       # exits the script block after `npm install` completes.
       - script: |
-          cd script\vsts
+          cd script/vsts
           npm install
         displayName: npm install
-      - script: node script\vsts\get-release-version.js
+      - script: node script/vsts/get-release-version.js
         name: Version
 
   # Import OS-specific build definitions

--- a/script/vsts/release-branch-build.yml
+++ b/script/vsts/release-branch-build.yml
@@ -9,10 +9,10 @@ jobs:
       # This has to be done separately because VSTS inexplicably
       # exits the script block after `npm install` completes.
       - script: |
-          cd script\vsts
+          cd script/vsts
           npm install
         displayName: npm install
-      - script: node script\vsts\get-release-version.js
+      - script: node script/vsts/get-release-version.js
         name: Version
 
   # Import OS-specific build definitions.
@@ -44,7 +44,7 @@ jobs:
       # This has to be done separately because VSTS inexplicably
       # exits the script block after `npm install` completes.
       - script: |
-          cd script\vsts
+          cd script/vsts
           npm install
         env:
           GITHUB_TOKEN: $(GITHUB_TOKEN)
@@ -57,7 +57,7 @@ jobs:
         displayName: Download Release Artifacts
 
       - script: |
-          node $(Build.SourcesDirectory)\script\vsts\upload-artifacts.js --create-github-release --assets-path "$(System.ArtifactsDirectory)" --linux-repo-name "atom-staging"
+          node $(Build.SourcesDirectory)/script/vsts/upload-artifacts.js --create-github-release --assets-path "$(System.ArtifactsDirectory)" --linux-repo-name "atom-staging"
         env:
           GITHUB_TOKEN: $(GITHUB_TOKEN)
           ATOM_RELEASE_VERSION: $(ReleaseVersion)
@@ -69,7 +69,7 @@ jobs:
         condition: and(succeeded(), eq(variables['Atom.AutoDraftRelease'], 'true'), eq(variables['IsReleaseBranch'], 'true'))
 
       - script: |
-          node $(Build.SourcesDirectory)\script\vsts\upload-artifacts.js --assets-path "$(System.ArtifactsDirectory)" --s3-path "vsts-artifacts/$(Build.BuildId)/"
+          node $(Build.SourcesDirectory)/script/vsts/upload-artifacts.js --assets-path "$(System.ArtifactsDirectory)" --s3-path "vsts-artifacts/$(Build.BuildId)/"
         env:
           ATOM_RELEASE_VERSION: $(ReleaseVersion)
           ATOM_RELEASES_S3_KEY: $(ATOM_RELEASES_S3_KEY)


### PR DESCRIPTION
Backslashes "\\" in these paths can be interpreted as escape characters
on Unix (Linux, macOS). Replace with forward-slashes, "/",
which are interpreted the same (as subdirectory indicator) everywhere.

⚛👋 Hello there! Welcome. Please follow the steps below to tell us about your contribution.

1. Copy the correct template for your contribution
  - 🐛 Are you fixing a bug? Copy the template from <https://bit.ly/atom-bugfix-pr>
  - 📈 Are you improving performance? Copy the template from <https://bit.ly/atom-perf-pr>
  - 📝 Are you updating documentation? Copy the template from <https://bit.ly/atom-docs-pr>
  - 💻 Are you changing functionality? Copy the template from <https://bit.ly/atom-behavior-pr>
2. Replace this text with the contents of the template
3. Fill in all sections of the template
4. Click "Create pull request"
